### PR TITLE
parse pkg ver/rel from spec; specify dep versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "2.7"
+before_install:
+  - "pip install -U pip setuptools virtualenv"
 install:
   - "python source/setup.py install"
 script:

--- a/README
+++ b/README
@@ -71,10 +71,18 @@ INSTALLATION
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Install directly from Fedora/Copr repository or use PIP::
 
+    # Basic dependencies for buiding/installing pip packages
     sudo yum install gcc krb5-devel
+    sudo yum install python-devel python-pip python-virtualenv
+
+    # Upgrade to the latest pip/setup/virtualenv installer code
+    sudo pip install -U pip setuptools virtualenv
+
+    # Install into a python virtual environment (OPTIONAL)
     virtualenv --no-site-packages ~/virtenv_statusreport
     source ~/virtenv_statusreport/bin/activate
-    pip install -U pip setuptools
+
+    # Install status_report (sudo required if not in a virtualenv)
     pip install status_report
 
 
@@ -82,7 +90,7 @@ TESTS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 To run tests using pytest::
 
-    pip install pytest
+    pip install pytest  (sudo required if not in a virtualenv)
     py.test source/tests
 
 

--- a/source/setup.py
+++ b/source/setup.py
@@ -2,10 +2,26 @@
 # -*- coding: utf-8 -*-
 # Author: "Chris Ward" <cward@redhat.com>
 
+import os
+import re
 from setuptools import setup
 
+script_pth = os.path.dirname(os.path.realpath(__file__))
+# make sure we're working from the root where (this) setup.py is
+os.chdir(script_pth)
+# get the parents directory path to find spec and README
+parent_pth = os.path.realpath('../')
+
+# Parse the version and release from master spec file
+# RPM spec file is in the parent directory
+spec_pth = os.path.join(parent_pth, 'status-report.spec')
+with open(spec_pth) as f:
+    lines = "\n".join(l.rstrip() for l in f)
+    version = re.search('Version: (.+)', lines).group(1).rstrip()
+    release = re.search('Release: (\d+)', lines).group(1).rstrip()
+
 # acceptable version schema: major.minor[.patch][sub]
-__version__ = '0.1.2'
+__version__ = '.'.join([version, release])
 __pkg__ = 'status_report'
 __pkgdir__ = {'status_report': 'status_report'}
 __pkgs__ = [
@@ -15,18 +31,16 @@ __pkgs__ = [
 __provides__ = ['status_report']
 __desc__ = 'Status Report - Comfortable CLI Activity Status Reporting'
 __scripts__ = ['status-report']
-__requires__ = [
-    'python_dateutil',
-    'kerberos',
-]
 __irequires__ = [
-    'python_dateutil',
-    'kerberos',
+    'python_dateutil==2.4.2',
+    'kerberos==1.2.2',
 ]
 pip_src = 'https://pypi.python.org/packages/source'
 __deplinks__ = []
 
-with open('../README') as _file:
+# README is in the parent directory
+readme_pth = os.path.join(parent_pth, 'README')
+with open(readme_pth) as _file:
     readme = _file.read()
 
 github = 'https://github.com/psss/status-report'
@@ -57,7 +71,6 @@ default_setup = dict(
     package_dir=__pkgdir__,
     packages=__pkgs__,
     provides=__provides__,
-    requires=__requires__,
     scripts=__scripts__,
     version=__version__,
     zip_safe=False,  # we reference __file__; see [1]


### PR DESCRIPTION
Squashed commit of the following:

commit 4b669826e5eed13813fb41f7e61fd34c7e268b8e
Author: Chris Ward <cward@redhat.com>
Date:   Thu Apr 23 12:22:41 2015 +0200

    updated readme; minor cleanup

commit 643ae00258ab165fbcb842e97e9bada54f60ca2f
Author: Chris Ward <cward@redhat.com>
Date:   Thu Apr 23 12:07:51 2015 +0200

    specify dep pkg version for kerb too helps?

commit 1a95f462d5292582c3097544d82ebe0ded8f55a4
Author: Chris Ward <cward@redhat.com>
Date:   Thu Apr 23 12:03:39 2015 +0200

    specify dep pkg version

commit bf26f4b6bdf155ccfbf366e1049ac26a6c717066
Author: Chris Ward <cward@redhat.com>
Date:   Thu Apr 23 11:50:12 2015 +0200

    manual install of kerberos module required to avoid crash

commit d1644564b5105b4bbd8666188a2916860c02c76b
Author: Chris Ward <cward@redhat.com>
Date:   Thu Apr 23 11:30:41 2015 +0200

    maybe build issue is container related?

commit bd9046b5dd4df6b50e7ce218669884fd66df5277
Author: Chris Ward <cward@redhat.com>
Date:   Thu Apr 23 11:12:43 2015 +0200

    readme linkage fixed; parse ver/rel from spec