### PR TITLE
add jira config example

### DIFF
--- a/examples/config
+++ b/examples/config
@@ -49,3 +49,9 @@ header = Work on projects
 item1 = Project One
 item2 = Project Two
 item3 = Project Three
+
+[jboss]
+type = jira
+prefix = JIRA
+project = ORG
+url = https://issues.jboss.org/


### PR DESCRIPTION
I keep having to search for a jira config example to figure out which variables are needed, etc. Let's just include one in examples/config, no?